### PR TITLE
Add path gatsby gh-pages path prefix

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,7 +4,7 @@ module.exports = {
     description: 'New support docs for the Social Programs portfolio',
     keywords: 'wh,docs',
   },
-  pathPrefix: ``,
+  pathPrefix: `/wh-support-docs`,
   plugins: [
     {
       resolve: 'gatsby-plugin-manifest',


### PR DESCRIPTION
Change required to fix the navigation and media urls for GitHub Pages hosted gatsby sites