### PR TITLE
V8 course bug fix

### DIFF
--- a/src/pages/spm/education/training_courses.mdx
+++ b/src/pages/spm/education/training_courses.mdx
@@ -91,7 +91,7 @@ of the IBM Cúram SPM Platform 7.X, including testers, project managers, and pro
 
 + **Course description:** This course provides a solid grounding in the Cúram model-driven development approach and ADE. It presents an architectural overview of the Cúram application and introduces ADE features and tools for modeling, coding, building, and troubleshooting applications.
 
-+ **Audience:** This course is intended primarily for developers and technical architects who will work on Cúram implementation projects. The course is also useful for anyone who needs a technical understanding of Merative Cúram SPM Platform 7.X, including testers and support engineers.
++ **Audience:** This course is intended primarily for developers and technical architects who will work on Cúram implementation projects. The course is also useful for anyone who needs a technical understanding of Merative Cúram SPM Platform 8.X, including testers and support engineers.
 
 ### CUR091 Merative Cúram for Developers (Customization) 8.X ###
 
@@ -99,7 +99,7 @@ of the IBM Cúram SPM Platform 7.X, including testers, project managers, and pro
 
 + **Course description:** Teams building Cúram SPM solutions for customers must be able to analyze and customize out-of-the-box (OOTB) solutions. The first part of the course describes the approach that Cúram SPM uses for customizing OOTB applications compliantly, including how to customize client and server artifacts, as well as source code and non-source code artifacts. The course also outlines how REST and web services are used for integrating with external applications and how custom features can be implemented using events, deferred processes, and batch processes.
 
-+ **Audience:** This course is intended primarily for developers and technical architects who will work on Cúram implementation projects. The course is also useful for anyone who needs a technical understanding of Cúram SPM Platform 7.X, including testers and support engineers.
++ **Audience:** This course is intended primarily for developers and technical architects who will work on Cúram implementation projects. The course is also useful for anyone who needs a technical understanding of Cúram SPM Platform 8.X, including testers and support engineers.
 
 ### 9D73G/CUR073 IBM Cúram SPM for Developers (ADE) 7.X ###
 


### PR DESCRIPTION
Fixing incorrect ref to 7.X in the Audience sections of the new CUR090 and CUR091 entries