### PR TITLE
SPM-145740 JM Prereqs JDK clarifications

### DIFF
--- a/src/pages/spm/prerequisites/820_modernjava.mdx
+++ b/src/pages/spm/prerequisites/820_modernjava.mdx
@@ -56,6 +56,9 @@ The Linux® platform is supported for building the application on a server.
 
 [Back to top](#top)
 
+## Java Requirements
+Details regarding Java version requirements are provided in each section where applicable.
+
 ## Prerequisites
 
 ### Installation
@@ -66,8 +69,8 @@ Java is required to run the Merative™ Cúram installers and the following vers
 
 |Prerequisite|Version|
 |-------|----|
-|Adoptium OpenJDK|21 and future fix packs|
-|IBM® Runtime Environment, Java Technology Edition|21 and future fix packs|
+|Eclipse Temurin™ |21 and future fix packs|
+|IBM® Semeru Runtime , Open or Certified Edition|21 and future fix packs|
 |Oracle Java SDK/JRE/JDK|21 and future fix packs|
 
 [Back to top](#top)
@@ -109,7 +112,7 @@ Container and Kubernetes platforms are supported on these application servers.
 
 |Supported software|Version|Details|
 |------------------|-------|-------|
-|IBM WebSphere Liberty|24.0.0.6 and future fix packs|The JDK (Java Development Kit) version 21 and future fix packs.|
+|IBM WebSphere Liberty|24.0.0.6 and future fix packs|IBM® Semeru JDK 21 and future fix packs - see [IBM WebSphere Liberty 24.0.0.6 support details](https://www.ibm.com/support/pages/24006-websphere-application-server-liberty-24006)|
 
 [Back to Supported software](#supported-software)
 
@@ -145,10 +148,10 @@ Although technical support is not provided for any Integrated Development Enviro
 |Supported software|Version|Details|
 |------------------|-------|-------|
 |Apache Ant|1.10.15|Please note that only Apache Ant 1.10.15 is supported. Associated fix packs are not.|
-|Eclipse|4.30 and future fix packs|Eclipse 4.30.0 and [higher maintenance releases](https://www.eclipse.org/downloads/packages/release/2023-12/r). Servlet Containers/Application Servers: Apache Tomcat [9.0.99](https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.99/), with [Eclipse Tomcat Plugin](https://sourceforge.net/projects/tomcatplugin/files/updatesite/plugins/) 9.1.7. Java SE: IBM and Oracle Java SE JDK 8.0 and [higher updates](http://www.oracle.com/technetwork/java/javase/downloads/index.html). Java EE: Oracle Java EE 6 and 7 and [higher updates](http://www.oracle.com/technetwork/java/javaee/downloads/java-archive-downloads-eesdk-419427.html). |
-|Rational Software Architect Designer|9.7.1.2|**Recommended version for the Windows 11 platform**. Supported as a Modeling Environment. Servlet Containers/Application Servers: Apache Tomcat 9.0.99, with Eclipse Tomcat Plugin 9.0.1. Java SE: IBM and Oracle Java SE JDK 8.0 and higher updates. Java EE: Oracle Java EE 6 and 7 and higher updates.|
-|Java|Adoptium OpenJDK 21 and future fix packs|Can be used for Cúram Development.|
-||IBM JDK 21 and future fix packs|Can be used for Cúram Development.|
+|Eclipse|4.30 and future fix packs|Eclipse 4.30.0 and [higher maintenance releases](https://www.eclipse.org/downloads/packages/release/2023-12/r). Servlet Containers/Application Servers: Apache Tomcat [9.0.99](https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.99/), with [Eclipse Tomcat Plugin](https://sourceforge.net/projects/tomcatplugin/files/updatesite/plugins/) 9.1.7. Java: JDKs supported are those specified in the rows below. |
+|Rational Software Architect Designer|9.7.1.2|**Recommended version for the Windows 11 platform**. Supported as a Modeling Environment.  Java SE: Modern Java is not supported by RSAD so IBM® SDK, Java™ Technology Edition, Version 8, Eclipse Temurin™ JDK 8 or Oracle Java SE JDK 8.0 is still required.|
+|Java|Eclipse Temurin™ JDK 21 and future fix packs|Can be used for Cúram Development.|
+||IBM® Semeru JDK 21 and future fix packs|Can be used for Cúram Development.|
 ||Oracle JDK 21 and future fix packs|Can be used for Cúram Development.|
 
 [Back to Supported software](#supported-software)
@@ -176,7 +179,7 @@ feature. The Java versions specified in the table below are certified for this p
 
 |Supported software|Version|Details|
 |------------------|-------|-------|
-|Adoptium OpenJDK|21 and future fix packs|Adoptium OpenJDK Version 21.0 is available as a free download from the [Adoptium Home Page](https://adoptium.net). |
+|Eclipse Temurin™|21 and future fix packs|Eclipse Temurin™ Version JDK 21.0 is available as a free download from the [Adoptium Home Page](https://adoptium.net). |
 |Microsoft Word|2021 and future fix packs|Required for creating and editing Cúram communication documents in Microsoft Word format.|
 
 [Back to Supported software](#supported-software)

--- a/src/pages/spm/prerequisites/820_modernjava.mdx
+++ b/src/pages/spm/prerequisites/820_modernjava.mdx
@@ -149,7 +149,7 @@ Although technical support is not provided for any Integrated Development Enviro
 |------------------|-------|-------|
 |Apache Ant|1.10.15|Please note that only Apache Ant 1.10.15 is supported. Associated fix packs are not.|
 |Eclipse|4.30 and future fix packs|Eclipse 4.30.0 and [higher maintenance releases](https://www.eclipse.org/downloads/packages/release/2023-12/r). Servlet Containers/Application Servers: Apache Tomcat [9.0.99](https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.99/), with [Eclipse Tomcat Plugin](https://sourceforge.net/projects/tomcatplugin/files/updatesite/plugins/) 9.1.7. Java: JDKs supported are those specified in the rows below. |
-|Rational Software Architect Designer|9.7.1.2|**Recommended version for the Windows 11 platform**. Supported as a Modeling Environment.  Java SE: Modern Java is not supported by RSAD so IBM® SDK, Java™ Technology Edition, Version 8, Eclipse Temurin™ JDK 8 or Oracle Java SE JDK 8.0 is still required.|
+|Rational Software Architect Designer|9.7.1.2|**Recommended version for the Windows 11 platform**. Supported as a Modeling Environment.  Java SE: Modern Java is not supported by RSAD so IBM® SDK, Java™ Technology Edition, Version 8 is still required.|
 |Java|Eclipse Temurin™ JDK 21 and future fix packs|Can be used for Cúram Development.|
 ||IBM® Semeru JDK 21 and future fix packs|Can be used for Cúram Development.|
 ||Oracle JDK 21 and future fix packs|Can be used for Cúram Development.|

--- a/src/pages/spm/prerequisites/821_modernjava.mdx
+++ b/src/pages/spm/prerequisites/821_modernjava.mdx
@@ -56,6 +56,9 @@ The Linux® platform is supported for building the application on a server.
 
 [Back to top](#top)
 
+## Java Requirements
+Details regarding Java version requirements are provided in each section where applicable.
+
 ## Prerequisites
 
 ### Installation
@@ -66,8 +69,8 @@ Java is required to run the Merative™ Cúram installers and the following vers
 
 |Prerequisite|Version|
 |-------|----|
-|Adoptium OpenJDK|21 and future fix packs|
-|IBM® Runtime Environment, Java Technology Edition|21 and future fix packs|
+|Eclipse Temurin™ |21 and future fix packs|
+|IBM® Semeru Runtime , Open or Certified Edition|21 and future fix packs|
 |Oracle Java SDK/JRE/JDK|21 and future fix packs|
 
 [Back to top](#top)
@@ -109,7 +112,7 @@ Container and Kubernetes platforms are supported on these application servers.
 
 |Supported software|Version|Details|
 |------------------|-------|-------|
-|IBM WebSphere Liberty|24.0.0.6 and future fix packs|The JDK (Java Development Kit) version 21 and future fix packs.|
+|IBM WebSphere Liberty|24.0.0.6 and future fix packs|IBM® Semeru JDK 21 and future fix packs - see [IBM WebSphere Liberty 24.0.0.6 support details](https://www.ibm.com/support/pages/24006-websphere-application-server-liberty-24006)|
 
 [Back to Supported software](#supported-software)
 
@@ -145,10 +148,10 @@ Although technical support is not provided for any Integrated Development Enviro
 |Supported software|Version|Details|
 |------------------|-------|-------|
 |Apache Ant|1.10.15|Please note that only Apache Ant 1.10.15 is supported. Associated fix packs are not.|
-|Eclipse|4.30 and future fix packs|Eclipse 4.30.0 and [higher maintenance releases](https://www.eclipse.org/downloads/packages/release/2023-12/r). Servlet Containers/Application Servers: Apache Tomcat [9.0.99](https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.99/), with [Eclipse Tomcat Plugin](https://sourceforge.net/projects/tomcatplugin/files/updatesite/plugins/) 9.1.7. Java SE: IBM and Oracle Java SE JDK 8.0 and [higher updates](http://www.oracle.com/technetwork/java/javase/downloads/index.html). Java EE: Oracle Java EE 6 and 7 and [higher updates](http://www.oracle.com/technetwork/java/javaee/downloads/java-archive-downloads-eesdk-419427.html). |
-|Rational Software Architect Designer|9.7.1.2|**Recommended version for the Windows 11 platform**. Supported as a Modeling Environment. Servlet Containers/Application Servers: Apache Tomcat 9.0.99, with Eclipse Tomcat Plugin 9.0.1. Java SE: IBM and Oracle Java SE JDK 8.0 and higher updates. Java EE: Oracle Java EE 6 and 7 and higher updates.|
-|Java|Adoptium OpenJDK 21 and future fix packs|Can be used for Cúram Development.|
-||IBM JDK 21 and future fix packs|Can be used for Cúram Development.|
+|Eclipse|4.30 and future fix packs|Eclipse 4.30.0 and [higher maintenance releases](https://www.eclipse.org/downloads/packages/release/2023-12/r). Servlet Containers/Application Servers: Apache Tomcat [9.0.99](https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.99/), with [Eclipse Tomcat Plugin](https://sourceforge.net/projects/tomcatplugin/files/updatesite/plugins/) 9.1.7. Java: JDKs supported are those specified in the rows below. |
+|Rational Software Architect Designer|9.7.1.2|**Recommended version for the Windows 11 platform**. Supported as a Modeling Environment.  Java SE: Modern Java is not supported by RSAD so IBM® SDK, Java™ Technology Edition, Version 8, Eclipse Temurin™ JDK 8 or Oracle Java SE JDK 8.0 is still required.|
+|Java|Eclipse Temurin™ JDK 21 and future fix packs|Can be used for Cúram Development.|
+||IBM® Semeru JDK 21 and future fix packs|Can be used for Cúram Development.|
 ||Oracle JDK 21 and future fix packs|Can be used for Cúram Development.|
 
 [Back to Supported software](#supported-software)
@@ -176,7 +179,7 @@ feature. The Java versions specified in the table below are certified for this p
 
 |Supported software|Version|Details|
 |------------------|-------|-------|
-|Adoptium OpenJDK|21 and future fix packs|Adoptium OpenJDK Version 21.0 is available as a free download from the [Adoptium Home Page](https://adoptium.net). |
+|Eclipse Temurin™|21 and future fix packs|Eclipse Temurin™ Version JDK 21.0 is available as a free download from the [Adoptium Home Page](https://adoptium.net). |
 |Microsoft Word|2021 and future fix packs|Required for creating and editing Cúram communication documents in Microsoft Word format.|
 
 [Back to Supported software](#supported-software)

--- a/src/pages/spm/prerequisites/821_modernjava.mdx
+++ b/src/pages/spm/prerequisites/821_modernjava.mdx
@@ -149,7 +149,7 @@ Although technical support is not provided for any Integrated Development Enviro
 |------------------|-------|-------|
 |Apache Ant|1.10.15|Please note that only Apache Ant 1.10.15 is supported. Associated fix packs are not.|
 |Eclipse|4.30 and future fix packs|Eclipse 4.30.0 and [higher maintenance releases](https://www.eclipse.org/downloads/packages/release/2023-12/r). Servlet Containers/Application Servers: Apache Tomcat [9.0.99](https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.99/), with [Eclipse Tomcat Plugin](https://sourceforge.net/projects/tomcatplugin/files/updatesite/plugins/) 9.1.7. Java: JDKs supported are those specified in the rows below. |
-|Rational Software Architect Designer|9.7.1.2|**Recommended version for the Windows 11 platform**. Supported as a Modeling Environment.  Java SE: Modern Java is not supported by RSAD so IBM® SDK, Java™ Technology Edition, Version 8, Eclipse Temurin™ JDK 8 or Oracle Java SE JDK 8.0 is still required.|
+|Rational Software Architect Designer|9.7.1.2|**Recommended version for the Windows 11 platform**. Supported as a Modeling Environment.  Java SE: Modern Java is not supported by RSAD so IBM® SDK, Java™ Technology Edition, Version 8 is still required.|
 |Java|Eclipse Temurin™ JDK 21 and future fix packs|Can be used for Cúram Development.|
 ||IBM® Semeru JDK 21 and future fix packs|Can be used for Cúram Development.|
 ||Oracle JDK 21 and future fix packs|Can be used for Cúram Development.|


### PR DESCRIPTION
* Adds header to indicate that details of java version will be called out in relevant sections where appropriate.
* replaces IBM JDK 21 with IBM Semeru JDK 21
* replaces Adoptium JDK 21 with Eclipse Temurin JDK 21
* Updates Dev tools section row for RAD that it needs java 8
* Updates Dev tools section row for Eclipse that jdks supported are those in table rows below.