### PR TITLE
SPM-146219 JM Prereqs removing Temurin references for installer and d…

### DIFF
--- a/src/pages/spm/prerequisites/820_modernjava.mdx
+++ b/src/pages/spm/prerequisites/820_modernjava.mdx
@@ -69,7 +69,6 @@ Java is required to run the Merative™ Cúram installers and the following vers
 
 |Prerequisite|Version|
 |-------|----|
-|Eclipse Temurin™ |21 and future fix packs|
 |IBM® Semeru Runtime , Open or Certified Edition|21 and future fix packs|
 |Oracle Java SDK/JRE/JDK|21 and future fix packs|
 
@@ -150,7 +149,6 @@ Although technical support is not provided for any Integrated Development Enviro
 |Apache Ant|1.10.15|Please note that only Apache Ant 1.10.15 is supported. Associated fix packs are not.|
 |Eclipse|4.30 and future fix packs|Eclipse 4.30.0 and [higher maintenance releases](https://www.eclipse.org/downloads/packages/release/2023-12/r). Servlet Containers/Application Servers: Apache Tomcat [9.0.99](https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.99/), with [Eclipse Tomcat Plugin](https://sourceforge.net/projects/tomcatplugin/files/updatesite/plugins/) 9.1.7. Java: JDKs supported are those specified in the rows below. |
 |Rational Software Architect Designer|9.7.1.2|**Recommended version for the Windows 11 platform**. Supported as a Modeling Environment.  Java SE: Modern Java is not supported by RSAD so IBM® SDK, Java™ Technology Edition, Version 8 is still required.|
-|Java|Eclipse Temurin™ JDK 21 and future fix packs|Can be used for Cúram Development.|
 ||IBM® Semeru JDK 21 and future fix packs|Can be used for Cúram Development.|
 ||Oracle JDK 21 and future fix packs|Can be used for Cúram Development.|
 

--- a/src/pages/spm/prerequisites/821_modernjava.mdx
+++ b/src/pages/spm/prerequisites/821_modernjava.mdx
@@ -69,7 +69,6 @@ Java is required to run the Merative™ Cúram installers and the following vers
 
 |Prerequisite|Version|
 |-------|----|
-|Eclipse Temurin™ |21 and future fix packs|
 |IBM® Semeru Runtime , Open or Certified Edition|21 and future fix packs|
 |Oracle Java SDK/JRE/JDK|21 and future fix packs|
 
@@ -150,7 +149,6 @@ Although technical support is not provided for any Integrated Development Enviro
 |Apache Ant|1.10.15|Please note that only Apache Ant 1.10.15 is supported. Associated fix packs are not.|
 |Eclipse|4.30 and future fix packs|Eclipse 4.30.0 and [higher maintenance releases](https://www.eclipse.org/downloads/packages/release/2023-12/r). Servlet Containers/Application Servers: Apache Tomcat [9.0.99](https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.99/), with [Eclipse Tomcat Plugin](https://sourceforge.net/projects/tomcatplugin/files/updatesite/plugins/) 9.1.7. Java: JDKs supported are those specified in the rows below. |
 |Rational Software Architect Designer|9.7.1.2|**Recommended version for the Windows 11 platform**. Supported as a Modeling Environment.  Java SE: Modern Java is not supported by RSAD so IBM® SDK, Java™ Technology Edition, Version 8 is still required.|
-|Java|Eclipse Temurin™ JDK 21 and future fix packs|Can be used for Cúram Development.|
 ||IBM® Semeru JDK 21 and future fix packs|Can be used for Cúram Development.|
 ||Oracle JDK 21 and future fix packs|Can be used for Cúram Development.|
 


### PR DESCRIPTION

As per SPM-146219 - Remove Temurin from Modern Java prereqs 820 and 821.

- remove Temurin as a supported jdk for install
- remove Temurin as a supported jdk for dev tools
- Temurin for Word integration is fine.